### PR TITLE
test case for https://github.com/parcel-bundler/parcel/issues/6002

### DIFF
--- a/packages/core/integration-tests/test/integration/scss-import/.sassrc.js
+++ b/packages/core/integration-tests/test/integration/scss-import/.sassrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  includePaths: [
+    'nonlocal-scss'
+  ],
+};

--- a/packages/core/integration-tests/test/integration/scss-import/index.scss
+++ b/packages/core/integration-tests/test/integration/scss-import/index.scss
@@ -1,7 +1,11 @@
 @import 'foo';
 @import './bar.scss';
+@import '_baz.scss';
+@import 'quux';
 
 .index {
   color: $foo;
   background-color: $bar;
+  border-color: $baz;
+  text-decoration-color: $quux;
 }

--- a/packages/core/integration-tests/test/integration/scss-import/nonlocal-scss/_baz.scss
+++ b/packages/core/integration-tests/test/integration/scss-import/nonlocal-scss/_baz.scss
@@ -1,0 +1,5 @@
+$baz: red;
+
+.baz {
+  color: $baz;
+}

--- a/packages/core/integration-tests/test/integration/scss-import/nonlocal-scss/_quux.scss
+++ b/packages/core/integration-tests/test/integration/scss-import/nonlocal-scss/_quux.scss
@@ -1,0 +1,5 @@
+$quux: orange;
+
+.quux {
+  color: $quux;
+}

--- a/packages/core/integration-tests/test/sass.js
+++ b/packages/core/integration-tests/test/sass.js
@@ -78,6 +78,8 @@ describe('sass', function() {
     assert(css.includes('.index'));
     assert(css.includes('.foo'));
     assert(css.includes('.bar'));
+    assert(css.includes('.baz'));
+    assert(css.includes('.quux'));
   });
 
   it('should support requiring empty scss files', async function() {


### PR DESCRIPTION
# ↪️ Pull Request

Adds (currently failing) test case for https://github.com/parcel-bundler/parcel/issues/6002 but does not include code to fix the problem. When it is fixed, this test case will pass.

## 💻 Examples

Recent versions of parcel, and `v2` branch as of this commit, will not resolve `@import 'filename'` to `_filename.scss` in an `includePaths` directory, but specifying `@import '_filename.scss'` will.